### PR TITLE
[Refactor] 프론트와 상의 후 BaseResponse 변경 및 회원가입 Response 변경

### DIFF
--- a/src/main/java/com/petspace/dev/controller/OauthController.java
+++ b/src/main/java/com/petspace/dev/controller/OauthController.java
@@ -3,9 +3,9 @@ package com.petspace.dev.controller;
 import com.petspace.dev.dto.oauth.OauthRequestDto;
 import com.petspace.dev.dto.oauth.OauthResponseDto;
 import com.petspace.dev.service.OauthService;
+import com.petspace.dev.util.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,13 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class OauthController {
 
-    private final OauthService oAuthService;
+    private final OauthService oauthService;
 
     @PostMapping("/{provider}")
-    public ResponseEntity<OauthResponseDto> OauthLoginRequest(@PathVariable String provider,
-                                                              @RequestBody OauthRequestDto requestDto) {
+    public BaseResponse<OauthResponseDto> OauthLoginRequest(@PathVariable String provider,
+                                                            @RequestBody OauthRequestDto requestDto) {
         log.info("provider={}, accessToken={}", provider, requestDto.getAccessToken());
-        OauthResponseDto oAuthResponseDto = oAuthService.login(provider, requestDto);
-        return ResponseEntity.ok(oAuthResponseDto);
+        OauthResponseDto oauthResponseDto = oauthService.login(provider, requestDto);
+        return new BaseResponse<>(oauthResponseDto);
     }
 }

--- a/src/main/java/com/petspace/dev/controller/UserController.java
+++ b/src/main/java/com/petspace/dev/controller/UserController.java
@@ -4,6 +4,7 @@ import com.petspace.dev.dto.user.UserCheckEmailResponseDto;
 import com.petspace.dev.dto.user.UserJoinRequestDto;
 import com.petspace.dev.dto.user.UserLoginRequestDto;
 import com.petspace.dev.dto.user.UserLoginResponseDto;
+import com.petspace.dev.dto.user.UserResponseDto;
 import com.petspace.dev.service.UserService;
 import com.petspace.dev.util.BaseResponse;
 import lombok.RequiredArgsConstructor;
@@ -26,9 +27,9 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/users")
-    public BaseResponse<UserJoinRequestDto> join(@Valid @RequestBody UserJoinRequestDto joinRequestDto) {
-        userService.join(joinRequestDto);
-        return new BaseResponse<>(joinRequestDto);
+    public BaseResponse<UserResponseDto> join(@Valid @RequestBody UserJoinRequestDto joinRequestDto) {
+        UserResponseDto responseDto = userService.join(joinRequestDto);
+        return new BaseResponse<>(responseDto);
     }
 
     @GetMapping("/users/email-check")

--- a/src/main/java/com/petspace/dev/controller/UserController.java
+++ b/src/main/java/com/petspace/dev/controller/UserController.java
@@ -11,31 +11,33 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
 @RestController
+@RequestMapping("/app")
 @RequiredArgsConstructor
 @Slf4j
 public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/app/users")
+    @PostMapping("/users")
     public BaseResponse<UserJoinRequestDto> join(@Valid @RequestBody UserJoinRequestDto joinRequestDto) {
         userService.join(joinRequestDto);
         return new BaseResponse<>(joinRequestDto);
     }
 
-    @GetMapping("/app/users/email-check")
+    @GetMapping("/users/email-check")
     public BaseResponse<UserCheckEmailResponseDto> checkEmail(@RequestParam String email) {
         UserCheckEmailResponseDto checkEmailResponseDto = userService.checkEmailDuplicate(email);
         return new BaseResponse<>(checkEmailResponseDto);
     }
 
-    @PostMapping("/app/login")
+    @PostMapping("/login")
     public BaseResponse<UserLoginResponseDto> login(@Valid @RequestBody UserLoginRequestDto loginRequestDto) {
         UserLoginResponseDto loginResponseDto = userService.login(loginRequestDto);
         return new BaseResponse<>(loginResponseDto);

--- a/src/main/java/com/petspace/dev/dto/oauth/OauthRequestDto.java
+++ b/src/main/java/com/petspace/dev/dto/oauth/OauthRequestDto.java
@@ -1,10 +1,8 @@
 package com.petspace.dev.dto.oauth;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 public class OauthRequestDto {
 
     // 프론트에서 넘겨주는 accessToken, JWT 관련 아님에 주의!

--- a/src/main/java/com/petspace/dev/dto/oauth/OauthResponseDto.java
+++ b/src/main/java/com/petspace/dev/dto/oauth/OauthResponseDto.java
@@ -2,20 +2,12 @@ package com.petspace.dev.dto.oauth;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@Builder
 public class OauthResponseDto {
 
     private String email;
     private String accessToken;
     private String refreshToken;
-
-    @Builder
-    public OauthResponseDto(String email, String accessToken, String refreshToken) {
-        this.email = email;
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-    }
 }

--- a/src/main/java/com/petspace/dev/dto/user/UserResponseDto.java
+++ b/src/main/java/com/petspace/dev/dto/user/UserResponseDto.java
@@ -1,0 +1,15 @@
+package com.petspace.dev.dto.user;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponseDto {
+
+    private Long id;
+    private String email;
+    private String username;
+    private String nickname;
+    private String birth;
+}

--- a/src/main/java/com/petspace/dev/service/UserService.java
+++ b/src/main/java/com/petspace/dev/service/UserService.java
@@ -5,6 +5,7 @@ import com.petspace.dev.dto.user.UserCheckEmailResponseDto;
 import com.petspace.dev.dto.user.UserJoinRequestDto;
 import com.petspace.dev.dto.user.UserLoginRequestDto;
 import com.petspace.dev.dto.user.UserLoginResponseDto;
+import com.petspace.dev.dto.user.UserResponseDto;
 import com.petspace.dev.repository.UserRepository;
 import com.petspace.dev.util.exception.UserException;
 import com.petspace.dev.util.jwt.JwtProvider;
@@ -26,7 +27,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public Long join(UserJoinRequestDto joinRequestDto) {
+    public UserResponseDto join(UserJoinRequestDto joinRequestDto) {
 
         validateSignupDto(joinRequestDto);
 
@@ -34,7 +35,13 @@ public class UserService {
         String encodedPassword = passwordEncoder.encode(user.getPassword());
         user.encodePassword(encodedPassword);
         userRepository.save(user);
-        return user.getId();
+        return UserResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .birth(user.getBirth())
+                .build();
     }
 
     public UserLoginResponseDto login(UserLoginRequestDto loginRequestDto) {

--- a/src/main/java/com/petspace/dev/util/BaseResponse.java
+++ b/src/main/java/com/petspace/dev/util/BaseResponse.java
@@ -3,9 +3,7 @@ package com.petspace.dev.util;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import lombok.Builder;
 import lombok.Getter;
-import org.springframework.validation.FieldError;
 
 import static com.petspace.dev.util.BaseResponseStatus.SUCCESS;
 
@@ -36,27 +34,5 @@ public class BaseResponse<T> {
         this.responseMessage = status.getResponseMessage();
         this.responseCode = status.getResponseCode();
         this.result = null;
-    }
-
-    // Validation Exception, 형식 검증에서 여러 fieldError 들을 result 에 담아서 보내는 에러 처리
-    public BaseResponse(BaseResponseStatus status, T result) {
-        this.isSuccess = status.isSuccess();
-        this.responseMessage = status.getResponseMessage();
-        this.responseCode = status.getResponseCode();
-        this.result = result;
-    }
-
-    @Getter
-    @Builder
-    public static class ValidationError {
-        private final String field;
-        private final String message;
-
-        public static BaseResponse.ValidationError of(final FieldError fieldError) {
-            return BaseResponse.ValidationError.builder()
-                    .field(fieldError.getField())
-                    .message(fieldError.getDefaultMessage())
-                    .build();
-        }
     }
 }

--- a/src/main/java/com/petspace/dev/util/BaseResponseStatus.java
+++ b/src/main/java/com/petspace/dev/util/BaseResponseStatus.java
@@ -15,9 +15,8 @@ public enum BaseResponseStatus {
     /**
      * 2000 : Request 오류
      */
-
-    // Validation 예외
-    INVALID_INPUT(false, 2000, "입력값을 확인해주세요."),
+    // 입력값 예외 (검증)
+    INVALID_INPUT(false, 2000, "잘못된 입력이 존재합니다."),
 
     // JWT 예외
     EMPTY_JWT(false, 2001, "JWT를 입력해주세요."),
@@ -27,7 +26,7 @@ public enum BaseResponseStatus {
     // UserException
     DUPLICATED_EMAIL(false, 2010, "중복된 이메일입니다."),
     INVALID_CHECKED_PASSWORD(false, 2011, "비밀번호 확인 값이 다릅니다."),
-    INVALID_EMAIL_OR_PASSWORD(false, 2011, "이메일 혹은 비밀번호가 잘못되었습니다."),
+    INVALID_EMAIL_OR_PASSWORD(false, 2012, "이메일 혹은 비밀번호가 잘못되었습니다."),
 
     /**
      * 3000 : Response 오류

--- a/src/main/java/com/petspace/dev/util/BaseResponseStatus.java
+++ b/src/main/java/com/petspace/dev/util/BaseResponseStatus.java
@@ -11,7 +11,6 @@ public enum BaseResponseStatus {
      * 1000 : 요청 성공
      */
     SUCCESS(true, 1000, "요청에 성공하였습니다."),
-    NON_DUPLICATE_EMAIL(true, 1010, "사용가능한 이메일입니다."),
 
     /**
      * 2000 : Request 오류

--- a/src/main/java/com/petspace/dev/util/exception/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/petspace/dev/util/exception/handler/CustomExceptionHandler.java
@@ -7,9 +7,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import static com.petspace.dev.util.BaseResponseStatus.INVALID_INPUT;
 
 @RestControllerAdvice
@@ -17,21 +14,12 @@ import static com.petspace.dev.util.BaseResponseStatus.INVALID_INPUT;
 public class CustomExceptionHandler {
 
     @ExceptionHandler({MethodArgumentNotValidException.class})
-    public BaseResponse<Object> handleValidationException(MethodArgumentNotValidException e) {
-        List<BaseResponse.ValidationError> errors = getFieldErrors(e);
-        return new BaseResponse<>(INVALID_INPUT, errors);
+    public BaseResponse<Object> handleValidationException() {
+        return new BaseResponse<>(INVALID_INPUT);
     }
 
     @ExceptionHandler({UserException.class})
     public BaseResponse<Object> handleUserException(UserException e) {
         return new BaseResponse<>(e.getStatus());
-    }
-
-    private List<BaseResponse.ValidationError> getFieldErrors(MethodArgumentNotValidException e) {
-        return e.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .map(BaseResponse.ValidationError::of)
-                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## :: PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 버그 수정
  <br />

## :: 구현
- 프론트와 상의 후, 이전에 머지됐던 @Valid에서의 예외를 리스트로 변환하기로 했던 로직이 일반 예외 로직과 같이 responseMessage만 출력되도록 리팩토링하였습니다.
   - 즉, 예외 발생시, result에는 아무것도 안담겨서 응답됨
- 회원가입시, 입력한 정보(requestDto)의 내용을 모두 응답하는 것이 아닌, UserResponse로 바인딩하여 반환하였습니다.
   - 이후, [GET] 요청으로 유저의 상세정보를 반환해야 할 때, 재사용할 수 있을 것 같습니다.
<br />

## :: 특이 사항
- 구현 이외에, 짜잘한 수정이 존재합니다.
   - 예를 들어, url 정보가 조금 변경되었습니다. (e.g. api/users -> app/users)