### PR TITLE
[Fix] RoomDetail GetMapping path rename

### DIFF
--- a/src/main/java/com/petspace/dev/controller/RoomController.java
+++ b/src/main/java/com/petspace/dev/controller/RoomController.java
@@ -37,7 +37,7 @@ public class RoomController {
             @ApiResponse(responseCode = "1000", description = "요청에 성공하였습니다."),
             @ApiResponse(responseCode = "2030", description = "존재하지 않는 숙소 정보입니다.")
     })
-    @GetMapping("/app/room/{id}")
+    @GetMapping("/room/{id}")
     public BaseResponse<RoomDetailResponseDto> getRoomDetail(@PathVariable("id") Long roomId){
         RoomDetailResponseDto roomDetailResponseDto = roomService.getRoomDetail(roomId);
 


### PR DESCRIPTION
## :: PR 타입
- [ ] 기능 추가
- [ ] 리팩토링
- [x] 버그 수정
  <br />

## :: 구현
- RoomDetail API path @RequestMapping("/app") + @GetMapping("/app/room/{id}") 되어 /app 중복.
- @GetMapping("/room/{id}") 으로 수정

<br />

## :: 특이 사항
