### PR TITLE
[Fix] Reservation 생성 시 유효하지 않은 roomAvailable 에 대한 예외 추가

### DIFF
--- a/src/main/java/com/petspace/dev/domain/Reservation.java
+++ b/src/main/java/com/petspace/dev/domain/Reservation.java
@@ -97,6 +97,10 @@ public class Reservation extends BaseTimeEntity{
                 .filter(roomAvailable -> roomAvailable.getAvailableDay().toLocalDate().isBefore(endDate))
                 .collect(Collectors.toList());
 
+        if(roomAvailables.isEmpty()) {
+            throw new ReservationException(POST_RESERVATION_INVALID_ROOM_AVAILABLE_DATE);
+        }
+
         for(RoomAvailable roomAvailable : roomAvailables) {
             if(roomAvailable.getStatus() != Status.ACTIVE) {
                 throw new ReservationException(POST_RESERVATION_INVALID_ROOM_AVAILABLE_STATUS);

--- a/src/main/java/com/petspace/dev/util/BaseResponseStatus.java
+++ b/src/main/java/com/petspace/dev/util/BaseResponseStatus.java
@@ -54,7 +54,8 @@ public enum BaseResponseStatus {
     POST_RESERVATION_INVALID_STARTDATE(false, 2235, "예약 불가능한 날짜입니다."),
     PATCH_RESERVATION_INVALID_RESERVATION_STATUS(false, 2236, "유효하지 않은 예약입니다."),
     PATCH_RESERVATION_INVALID_USER(false, 2237, "유효하지 않은 유저의 접근입니다."),
-    NONE_RESERVATION(false, 2234, "존재하지 않는 예약입니다."),
+    NONE_RESERVATION(false, 2238, "존재하지 않는 예약입니다."),
+    POST_RESERVATION_INVALID_ROOM_AVAILABLE_DATE(false, 2239, "유효하지 않은 예약 날짜입니다."),
 
 
     // RoomException


### PR DESCRIPTION
## :: PR 타입
- [ ] 기능 추가
- [ ] 리팩토링
- [ x] 버그 수정
  <br />

## :: 구현
- Reservation 생성 시 유효하지 않은 roomAvailable 에 대한 예외 추가, 해당 날짜에 대한 roomAvailable 이 존재하지 않을 때 Reservation 이 생성되는 오류 해결

<br />

## :: 특이 사항
