### PR TITLE
[Feature] 로그인 여부에 따른 favorite check(하트) 여부 추가

### DIFF
--- a/src/main/java/com/petspace/dev/controller/RoomController.java
+++ b/src/main/java/com/petspace/dev/controller/RoomController.java
@@ -39,9 +39,17 @@ public class RoomController {
             @ApiResponse(responseCode = "2030", description = "존재하지 않는 숙소 정보입니다.")
     })
     @GetMapping("/room/{roomId}")
-    public BaseResponse<RoomDetailResponseDto> getRoomDetail(@PathVariable("roomId") Long roomId){
+    public BaseResponse<RoomDetailResponseDto> getRoomDetail(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("roomId") Long roomId){
 
-        RoomDetailResponseDto roomDetailResponseDto = roomService.getRoomDetail(roomId);
+        RoomDetailResponseDto roomDetailResponseDto;
+
+        if(principalDetails == null){
+            roomDetailResponseDto = roomService.getRoomDetail(roomId, null);
+        }else{
+            Long userId = principalDetails.getId();
+            roomDetailResponseDto = roomService.getRoomDetail(roomId, userId);
+        }
+
         return new BaseResponse(roomDetailResponseDto);
 
     }

--- a/src/main/java/com/petspace/dev/controller/RoomController.java
+++ b/src/main/java/com/petspace/dev/controller/RoomController.java
@@ -38,7 +38,7 @@ public class RoomController {
             @ApiResponse(responseCode = "1000", description = "요청에 성공하였습니다."),
             @ApiResponse(responseCode = "2030", description = "존재하지 않는 숙소 정보입니다.")
     })
-    @GetMapping("/room/{roomId}")
+    @GetMapping("/rooms/{roomId}")
     public BaseResponse<RoomDetailResponseDto> getRoomDetail(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("roomId") Long roomId){
 
         RoomDetailResponseDto roomDetailResponseDto;

--- a/src/main/java/com/petspace/dev/dto/room/RoomDetailResponseDto.java
+++ b/src/main/java/com/petspace/dev/dto/room/RoomDetailResponseDto.java
@@ -90,6 +90,7 @@ public class RoomDetailResponseDto {
         List<RoomDetailReview> reviewPreview = room.getReservation()
                 .stream().map(Reservation::getReview)
                 .filter(Objects::nonNull)
+                .filter(review -> review.getStatus().equals(Status.ACTIVE))
                 .sorted(Comparator.comparing(Review::getId).reversed())
                 .limit(5)
                 .map(review ->{

--- a/src/main/java/com/petspace/dev/dto/room/RoomDetailResponseDto.java
+++ b/src/main/java/com/petspace/dev/dto/room/RoomDetailResponseDto.java
@@ -13,8 +13,8 @@ import java.util.stream.Collectors;
 @Getter @Setter
 public class RoomDetailResponseDto {
 
-    // TODO isFavorite 추가 필요
     private Long roomId;
+    private boolean isFavorite;
     private Long hostId;
     private String hostName;
     private String address;
@@ -57,6 +57,7 @@ public class RoomDetailResponseDto {
                 .stream().map(Reservation::getReview)
                 .count();
         // Room 의 Image 리스트에서 URL 만을 List<String> 으로 받아오기
+        // TODO 추후 RoomImage Entity List 로 변경. 순환참조 문제 해결. Room Entity 내 List<String> 으로 갖는 것과 다를 바 없다.
         this.roomImageUrls = room.getRoomImages()
                 .stream().map(RoomImage::getRoomImageUrl)
                 .collect(Collectors.toList());

--- a/src/main/java/com/petspace/dev/service/RoomService.java
+++ b/src/main/java/com/petspace/dev/service/RoomService.java
@@ -1,8 +1,10 @@
 package com.petspace.dev.service;
 
+import com.petspace.dev.domain.Favorite;
 import com.petspace.dev.domain.Room;
 import com.petspace.dev.dto.room.RoomDetailResponseDto;
 import com.petspace.dev.dto.room.RoomFacilityResponseDto;
+import com.petspace.dev.repository.FavoriteRepository;
 import com.petspace.dev.repository.RoomRepository;
 import com.petspace.dev.util.exception.RoomException;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +18,31 @@ import static com.petspace.dev.util.BaseResponseStatus.*;
 public class RoomService {
 
     private final RoomRepository roomRepository;
+    private final FavoriteRepository favoriteRepository;
 
     @Transactional(readOnly = true)
-    public RoomDetailResponseDto getRoomDetail(Long roomId) {
+    public RoomDetailResponseDto getRoomDetail(Long roomId, Long userId) {
 
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(()-> new RoomException(NONE_ROOM));
 
-        return new RoomDetailResponseDto(room);
+        RoomDetailResponseDto roomDetailResponseDto = new RoomDetailResponseDto(room);
+
+        // 로그인 상태
+        if(userId != null){
+            Favorite favorite = favoriteRepository.findByUserIdAndRoomId(userId, roomId)
+                    .orElse(null);
+
+            if(favorite != null && favorite.isClicked() == true){
+                roomDetailResponseDto.setFavorite(true);
+            } else{
+                roomDetailResponseDto.setFavorite(false);
+            }
+        } else{
+            roomDetailResponseDto.setFavorite(false);
+        }
+
+        return roomDetailResponseDto;
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## :: PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
  <br />

## :: 구현
- 로그인 여부에 따라 favorite 이 체크되어 있는지를 RoomDetailResponse DTO 에 포함하였습니다.
- 로그인 시 (Header에 토큰 포함) 에는 좋아요 체크 여부에 따라 true / false 를 리턴합니다.
- 비로그인 시 (Header에 토큰 null) 에는 false 를 리턴합니다. -> FE에서 처리 로직에 따라 안 쓸 수도 있습니다. (ex. 비로그인시에는 하트를 아예 안보이게 처리한다면) (ex. 하트가 보이게 처리한다면, false 로 표시하되 버튼이 클릭되지 않도록)
<br />

## :: 특이 사항
