### PR TITLE
[Refactor] 함께 갈 곳 페이징 처리

### DIFF
--- a/src/main/java/com/petspace/dev/controller/FavoriteController.java
+++ b/src/main/java/com/petspace/dev/controller/FavoriteController.java
@@ -2,7 +2,7 @@ package com.petspace.dev.controller;
 
 import com.petspace.dev.domain.user.auth.PrincipalDetails;
 import com.petspace.dev.dto.favorite.FavoriteClickResponseDto;
-import com.petspace.dev.dto.favorite.FavoriteResponseDto;
+import com.petspace.dev.dto.favorite.FavoritesSliceResponseDto;
 import com.petspace.dev.service.FavoriteService;
 import com.petspace.dev.util.BaseResponse;
 import com.petspace.dev.util.input.room.RegionType;
@@ -11,14 +11,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/app")
@@ -36,12 +35,16 @@ public class FavoriteController {
             @ApiResponse(responseCode = "2099", description = "Request Parameter의 유형이 불일치합니다.")
     })
     @GetMapping("/favorites")
-    public BaseResponse<List<FavoriteResponseDto>> showFavorites(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                 @RequestParam RegionType region) {
+    public BaseResponse<FavoritesSliceResponseDto> showFavorites(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                 @RequestParam RegionType region,
+                                                                 @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+                                                                 @RequestParam(value = "size", required = false, defaultValue = "5") int size) {
         Long userId = principalDetails.getId();
-        List<FavoriteResponseDto> responseDtos = favoriteService.showFavoritesByRegion(userId, region.getKorRegionName());
-        return new BaseResponse<>(responseDtos);
+        PageRequest pageRequest = PageRequest.of(page, size);
+        FavoritesSliceResponseDto responseDto = favoriteService.showFavoritesSliceByRegion(userId, region.getKorRegionName(), pageRequest);
+        return new BaseResponse<>(responseDto);
     }
+
 
     @Operation(summary = "Favorite POST", description = "Favorite POST API Doc")
     @ApiResponses({

--- a/src/main/java/com/petspace/dev/dto/favorite/FavoritesResponseDto.java
+++ b/src/main/java/com/petspace/dev/dto/favorite/FavoritesResponseDto.java
@@ -20,7 +20,7 @@ import static com.petspace.dev.domain.Status.ACTIVE;
 @Getter
 @Builder
 @Slf4j
-public class FavoriteResponseDto {
+public class FavoritesResponseDto {
 
     private Long id;
     private List<String> roomImages;
@@ -30,7 +30,7 @@ public class FavoriteResponseDto {
     private int numberOfReview;
     private List<LocalDateTime> availableDays;
 
-    public static FavoriteResponseDto of(Favorite favorite) {
+    public static FavoritesResponseDto of(Favorite favorite) {
 
         // TODO Favorite을 Room으로 묶어서 리팩토링을 진행해야되나? 하나의 DTO / Service가 너무 많은 역할
         Room room = favorite.getRoom();
@@ -51,7 +51,7 @@ public class FavoriteResponseDto {
                 .map(RoomAvailable::getAvailableDay)
                 .collect(Collectors.toList());
 
-        return FavoriteResponseDto.builder()
+        return FavoritesResponseDto.builder()
                 .id(room.getId())
                 .roomImages(room.getRoomImages().stream().map(RoomImage::getRoomImageUrl).collect(Collectors.toList()))
                 .roomAddress(room.getAddress().getDistrict() + ", " + room.getAddress().getCity())

--- a/src/main/java/com/petspace/dev/dto/favorite/FavoritesSliceResponseDto.java
+++ b/src/main/java/com/petspace/dev/dto/favorite/FavoritesSliceResponseDto.java
@@ -1,0 +1,17 @@
+package com.petspace.dev.dto.favorite;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class FavoritesSliceResponseDto {
+    List<FavoriteResponseDto> favorites;
+
+    private long page;
+    @JsonProperty(value = "isLast")
+    private Boolean isLast;
+}

--- a/src/main/java/com/petspace/dev/dto/favorite/FavoritesSliceResponseDto.java
+++ b/src/main/java/com/petspace/dev/dto/favorite/FavoritesSliceResponseDto.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Getter
 @Builder
 public class FavoritesSliceResponseDto {
-    List<FavoriteResponseDto> favorites;
+    List<FavoritesResponseDto> favorites;
 
     private long page;
     @JsonProperty(value = "isLast")

--- a/src/main/java/com/petspace/dev/repository/FavoriteRepository.java
+++ b/src/main/java/com/petspace/dev/repository/FavoriteRepository.java
@@ -1,10 +1,11 @@
 package com.petspace.dev.repository;
 
 import com.petspace.dev.domain.Favorite;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
@@ -12,8 +13,9 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     Optional<Favorite> findByUserIdAndRoomId(Long userId, Long roomId);
 
     @Query("select f from Favorite f " +
-            "join fetch f.user u " +
-            "join fetch f.room r " +
-            "where u.id = :userId and r.address.region = :region and f.isClicked = true")
-    List<Favorite> findAllFavoritesByUserIdAndRegion(Long userId, String region);
+            "left join fetch f.user u " +
+            "left join fetch f.room r " +
+            "where f.isClicked = true and u.id = :userId and r.address.region = :region " +
+            "order by f.id desc")
+    Slice<Favorite> findAllFavoritesSliceBy(Long userId, String region, Pageable pageable);
 }


### PR DESCRIPTION
## :: PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 버그 수정
  <br />

## :: 구현
- 함께 갈 곳 리팩토링을 통한 페이징 처리 

<br />

## :: 특이 사항
- 페이징 처리를 위해 Slice를 사용하였습니다.

## :: 🔥필요 논의 사항🔥
**🔥 Room / Favorite에서 예약 가능한 날짜(RoomAvailable)를 빼는건 어떨까 싶습니다.**
  - 어떤 날짜를 표시할 건지 애매합니다.
    - e.g 1월 2일 ~ 1월 8일이 예약 가능한데, 1월 3일 ~ 1월 4일로 예약 되어 있는 경우, 1월 2일만 표시된 경우,
    - 사용자 입장에서 ‘아 이때만 예약가능하구나’ 로 착각할 수 있을 것 같습니다.
  - 날짜 표시를 빼고, 예약 API에서 가능한 날짜들만 나타내서 예약할 수 있도록 하는 건 어떨까 싶습니다.
    - 추가로 검색 조건에만 추가하는 것이 깔끔해보입니다.
  - 만약 빼는 경우, 불필요한 쿼리 발생을 막을 수 있습니다.

**🔥 User ↔︎ Review / Room ↔︎ Review 일대다 추가하는 게 어떨까 싶습니다.**
  - 위 둘을 일대다로 연관 관계를 추가하는 경우, 굳이 Reservation을 안타고 Review → User / Review → User 로 바로 접근이 가능하여 불필요한 쿼리를 줄일 수 있을 듯 합니다.
  - 현재는, Review 수, Review 총점을 계산하기 위해 Reservation 정보가 필요하여 Reservation 관련 쿼리가 불필요하게 발생합니다.