### PR TITLE
[Fix] room detail에서 유저 프로필 이미지 url 추가

### DIFF
--- a/src/main/java/com/petspace/dev/dto/room/RoomDetailResponseDto.java
+++ b/src/main/java/com/petspace/dev/dto/room/RoomDetailResponseDto.java
@@ -97,6 +97,7 @@ public class RoomDetailResponseDto {
                     Reservation reservation = review.getReservation();
                     RoomDetailReview roomDetailReviews = RoomDetailReview.builder()
                             .userId(reservation.getUser().getId())
+                            .profileImage(reservation.getUser().getProfileImage())
                             .nickname(reservation.getUser().getNickname())
                             .score(review.getScore())
                             .createdAt(calculateCreatedDateFromNow(review.getCreatedAt()))

--- a/src/main/java/com/petspace/dev/dto/room/RoomDetailReview.java
+++ b/src/main/java/com/petspace/dev/dto/room/RoomDetailReview.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 @Builder
 public class RoomDetailReview {
 
-    // TODO user image url 추가
     private Long userId;
+    private String profileImage;
     private String nickname;
     private int score;
     private String createdAt;


### PR DESCRIPTION
## :: PR 타입
- [ ] 기능 추가
- [ ] 리팩토링
- [X] 버그 수정
  <br />

## :: 구현
- room detail에서 유저 프로필 이미지 url 추가

<br />

## :: 특이 사항
- response dto 단에서, 프로필 이미지 url을 추가하였습니다.